### PR TITLE
feat(add-orchestrator): install-time divergence detection (--check + overwrite-prompt wiring) (#8)

### DIFF
--- a/plugins/agent-dev/.claude-plugin/plugin.json
+++ b/plugins/agent-dev/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-dev",
   "description": "Develop and extend existing agents \u2014 add skills, memory systems, GitHub Issues development workflow (backlog, roadmap, groom, claim, autoplan, commit, sprint, work-loop), long-running multi-stage pipelines (add-pipeline + heartbeat / status / recover / pause / resume runtime skills), system-aware orchestration (add-orchestrator \u2014 discover / compose / orchestrate a multi-agent system via Trinity's SystemManifest), a shared canonical-data layer (add-canon \u2014 a fleet canon repo with publish / consume / reconcile / doctor runtime skills and per-counterpart relations memory; add-canon-lint \u2014 deterministic consistency linting of the canon repo: two-zone schema, one-home-per-key facts, CI on every push), and fleet analysis + migration (agent-fleet-analysis \u2014 scan directories of agents in any paradigm, score fleet maturity / migration readiness, recommend a fleet architecture, map every gap to an installable marketplace skill, and emit a PDF report plus an agent-executable markdown work order; agent-fleet-migrate \u2014 execute that work order non-destructively: copy sources into a fresh workspace, extract logic per paradigm (n8n nodes / framework code / freeform prompts), delegate every fix to a named marketplace skill, verify each copy through the review gate, and report the before/after maturity delta with a gated Trinity deploy offer)",
-  "version": "1.14.0",
+  "version": "1.14.2",
   "author": {
     "name": "Ability.ai",
     "email": "support@ability.ai"

--- a/plugins/agent-dev/skills/add-orchestrator/SKILL.md
+++ b/plugins/agent-dev/skills/add-orchestrator/SKILL.md
@@ -3,11 +3,13 @@ name: add-orchestrator
 description: Make any agent a system-aware orchestrator — installs /discover-agents (discover the fleet from live Trinity and/or a repo list into a descriptive fleet/system-map.yaml), /compose-system (turn the map into a Trinity SystemManifest and deploy_system), and /orchestrate (route, fan out, and run ephemeral agents via Trinity MCP). Aligns with Trinity's existing SystemManifest; no parallel standard.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion, Skill
 user-invocable: true
+argument-hint: "[--check]"
 metadata:
-  version: "1.20"
+  version: "1.22"
   created: 2026-07-01
   author: Ability.ai
   changelog:
+    - "1.22: Install-time divergence detection (issue #8) — a read-only `--check` mode compares every installed runtime skill against its bundled template on three axes: `installed < bundled` (upgrade available), `installed > bundled` (BACK-PORT candidate — the field-hardened copy the marketplace should pull from, the signal issue #5 went weeks without), and equal version but differing content (local customization). Reported in the canon-doctor PASS/WARN/FAIL shape with a one-line fleet-readable verdict. Step 4's per-skill overwrite prompt now runs the same comparison, so the warning — a silent downgrade or an about-to-be-clobbered local edit — arrives at the moment of decision, not after. Deliberately scoped to add-orchestrator's own bundle and stateless; the plugin-framework-wide version is a separate follow-up. (Version skips 1.21, reserved for the open PR #7/#9.)"
     - "1.20: orchestrate template 1.13 — dispatch is a one-line playbook call resolved from the target's live get_agent_skills catalog (fleet convention protocols/playbook-call.md); prose briefs are the recorded exception"
     - "1.19: Platform caveat rewritten for ent#89 (materialized at creation, disabled unless a literal YAML true, max 20, deduped by name, never re-applied on recreate) and the steward entry now scaffolds enabled: false so a template-derived agent cannot silently inherit an armed unattended sweep. Dropped the non-schema `id:` key in favour of `name:` as the identity key. Steward cadence no longer claims 'server-local time' — schedules and the container clock are both UTC (#1795), and legacy IANA aliases now 500 on create (#1823). Bundled /orchestrate → v1.12 (rooms + A2A routing)"
     - "1.18: Bundled /orchestrate v1.11 — event-choreography layer for standing 'whenever X happens, have Y react' asks (fourth routing pattern next to Single/Fan-out/Chain): custom domain events via emit_event alongside the #1578 backend terminals, subscriptions wired SELF-SERVICE (subscribe_to_event always subscribes the caller — the orchestrator dispatches the setup task to the subscriber, never subscribes on-behalf), edges recorded in orchestration.md §6, and four unenforced design rules (exact-triple match/no wildcards; no loop guard outside agent.task.* — custom event graphs must stay acyclic; wakes reach only running subscribers, at-most-once/no replay; interpolated payloads are a cross-agent injection surface). Allowed-tools catches up: event tools + the set_reminder/cancel_reminder the v1.7 watchdog already instructed"
@@ -36,6 +38,8 @@ metadata:
 > ℹ️ **First, set expectations:** before anything else, print one short line with this skill's version and its most recent change — the top entry of `metadata.changelog` above — e.g. `add-orchestrator vX.Y — recent: <summary>`. Then proceed.
 
 Turn any Trinity-compatible agent into a **system-aware orchestrator**: an agent that knows what other agents exist (deployed *or* just sitting in a GitHub repo), what each can do, and can route work to them, batch across them, or roll one out ephemerally, use it, and spin it back down.
+
+> 🔍 **Already installed? `/add-orchestrator --check`** runs a read-only divergence report — per installed skill: upgrade available, back-port candidate (your copy is *ahead* of the bundle), or a local customization about to be clobbered — before you re-run and overwrite anything. See **Check mode** below.
 
 **Two modes — pick by whether the fleet already exists. Don't force a linear pipeline.**
 
@@ -98,6 +102,71 @@ Drive (opt-in project-management layer — Q3 at install):
 
 ## Process
 
+### Check mode (`--check`) — install-time divergence detection
+
+Invoked as `/add-orchestrator --check`: a **read-only** report of how this agent's *installed* runtime skills compare to the *bundled* templates they were copied from. Nothing is written, no files are touched. The same per-skill comparison is called inline by **Step 4**'s overwrite prompt, so the warning reaches the operator *at the moment of the overwrite decision*, not after it (issue #8). When `--check` is the invocation, run this section and stop — skip the install steps.
+
+**Scope is deliberate and stateless.** This compares only the skills add-orchestrator itself installs (`discover-agents`, `compose-system`, `orchestrate`, `sync-fleet-to-head`, `profile-fleet`, `fleet-reconcile`, and the Q3 pair `project-init` / `project-steward`) against *this bundle's* `templates/`. It is **not** a general skill-registry inventory and keeps **no state on disk** — the bundle is the reference, the installed copy is the subject. The plugin-framework-wide version (every plugin that copies skills into agent repos) is a separate, larger call filed as a follow-up.
+
+**Per skill, resolve two version stamps and compare content:**
+- `installed` = `metadata.version` in the agent's `.claude/skills/<skill>/SKILL.md`
+- `bundled`   = `metadata.version` in this skill's `templates/<skill>.md`
+
+Compare **numerically, per dotted component** — `1.9 < 1.13`, so a plain string compare is wrong. Then classify into the three states issue #8 asked for (the third is the one everyone forgets):
+
+| State | Verdict | Meaning |
+|---|---|---|
+| not installed | — (skip) | the agent never adopted this skill — a plain install, nothing to reconcile |
+| `installed == bundled`, content identical | **PASS** | in sync |
+| `installed == bundled`, content differs | **WARN** | **local customization** — the copy was hand-edited (e.g. a field-directive routing block). Surface the diff *before* an overwrite silently destroys it |
+| `installed < bundled` | **WARN** | **upgrade available** — the bundle moved ahead; overwriting pulls the copy forward |
+| `installed > bundled` | **FAIL** | **back-port candidate** — the *installed* copy is ahead of the bundle: a field-hardened local copy the marketplace should pull *from*, and overwriting it is a silent **downgrade**. The signal nobody was watching for weeks (issue #5) |
+
+`FAIL` here does not mean "broken" — it is the loudest state on purpose, because a back-port candidate and an about-to-be-clobbered customization are exactly the two failures issue #8 was filed for.
+
+**Mechanics** (read-only — resolves stamps, then diffs installed vs bundled):
+
+```bash
+SKILL_DIR="<this add-orchestrator skill's own directory>"
+ver()  { grep -m1 -E '^[[:space:]]*version:' "$1" 2>/dev/null | tr -dc '0-9.'; }
+# numeric dotted compare → prints <, =, or >
+vcmp() { awk -v a="$1" -v b="$2" 'BEGIN{
+  n=split(a,x,"."); m=split(b,y,"."); L=(n>m?n:m);
+  for(i=1;i<=L;i++){u=x[i]+0; v=y[i]+0; if(u<v){print "<";exit} if(u>v){print ">";exit}}
+  print "=" }'; }
+
+for skill in discover-agents compose-system orchestrate sync-fleet-to-head profile-fleet fleet-reconcile project-init project-steward; do
+  inst=".claude/skills/$skill/SKILL.md"; bund="$SKILL_DIR/templates/$skill.md"
+  [ -f "$inst" ] || { echo "$skill: — not installed"; continue; }
+  iv=$(ver "$inst"); bv=$(ver "$bund"); cmp=$(vcmp "$iv" "$bv")
+  if [ "$cmp" = "=" ]; then
+    if diff -q "$bund" "$inst" >/dev/null 2>&1; then echo "$skill: PASS in sync (v$iv)"
+    else echo "$skill: WARN local customization — installed v$iv == bundled, content differs"; fi
+  elif [ "$cmp" = "<" ]; then echo "$skill: WARN upgrade available — installed v$iv < bundled v$bv"
+  else echo "$skill: FAIL back-port candidate — installed v$iv > bundled v$bv (overwrite = downgrade)"; fi
+done
+```
+
+An installed copy is a byte-for-byte `cp` of `templates/<skill>.md` (Step 4 does no placeholder substitution), so on a clean install `diff -q` is exact and any difference at an equal version is a genuine local edit. To *show* the customization, run `diff "$bund" "$inst"` (or `git diff --no-index -- "$bund" "$inst"`) and print a compact hunk.
+
+**Why equal-version is the only clean customization signal.** The bundle carries only the *current* template, not the historical one a behind copy was made from. So at `installed < bundled` the diff mixes the upgrade delta with any local edits and cannot cleanly separate them; only at `installed == bundled` is every differing line a local customization. Show the full diff for the equal-version case; for the behind case, lead with the version gap and offer the (mixed) diff on request.
+
+**Report** — canon-doctor PASS/WARN/FAIL shape, ordered most-severe first (FAIL → WARN → PASS → not installed), closing with one verdict line an orchestrator can read fleet-wide:
+
+```
+add-orchestrator divergence check — <agent name>
+  profile-fleet       FAIL  back-port candidate — v1.6 > bundled v1.4 (overwrite = downgrade)
+  orchestrate         WARN  local customization — v1.13 == bundled, 12 lines differ (diff below)
+  sync-fleet-to-head  WARN  upgrade available — v1.0 < bundled v1.4
+  discover-agents     PASS  in sync (v1.7)
+  compose-system      PASS  in sync (v1.3)
+  fleet-reconcile     —     not installed
+
+  verdict: DIVERGED — 1 back-port candidate, 1 behind, 1 customized. Back-port profile-fleet into the bundle before overwriting; review the orchestrate diff before any re-copy.
+```
+
+`verdict: IN SYNC` needs every installed skill at PASS; WARN and FAIL both count against it. Keep the verdict to one line — orchestrators dispatch this fleet-wide and read only that line per agent.
+
 ### Step 1: Preflight
 
 Run from inside the target agent directory (the agent you want to *make* an orchestrator), or ask for the path.
@@ -129,7 +198,7 @@ Use `AskUserQuestion`:
 - `Core three` (discover-agents, compose-system, orchestrate) — the discover → compose → route trio, without the fleet-maintenance skills
 - `Discovery only` (discover-agents) — just build the system map; wire the rest later
 
-If any target skill directory already exists under `.claude/skills/`, ask per-skill: overwrite / skip / cancel. Never silently overwrite.
+If any target skill directory already exists under `.claude/skills/`, ask per-skill: overwrite / skip / cancel. Never silently overwrite — and never *blindly*: run the **Check mode** comparison for that skill first and fold its verdict into the prompt (Step 4 spells out how), so the operator sees an upgrade, a back-port candidate, or a local customization before choosing.
 
 **Q2 — Seed `fleet/sources.yaml` with the current repo list?** (free text, optional)
 - Offer to paste an initial list of repositories now (local paths and/or `github:Org/repo`), or start with the commented example and edit later.
@@ -186,7 +255,15 @@ mkdir -p fleet/project-steward/digests fleet/project-steward/outputs
 
 ### Step 4: Copy the selected runtime skills
 
-For each skill selected in Q1, copy its template. The templates are ready to use as-is — **no placeholder substitution** (they read `fleet/sources.yaml` / `fleet/system-map.yaml` at runtime and infer the agent name themselves):
+For each skill selected in Q1, copy its template. The templates are ready to use as-is — **no placeholder substitution** (they read `fleet/sources.yaml` / `fleet/system-map.yaml` at runtime and infer the agent name themselves).
+
+**Before overwriting any existing `.claude/skills/<skill>/SKILL.md`, run the Check-mode comparison for that one skill (above) and present its verdict inside the overwrite prompt** — this is the moment issue #8 exists for. Make the prompt say what the operator is about to do:
+- **PASS** (in sync) — nothing to warn about; the overwrite is a no-op. Offer skip as the default.
+- **upgrade available** (`installed < bundled`) — "orchestrate v1.11 → v1.13 (upgrade). Overwrite / skip / cancel." Overwrite is the safe default.
+- **local customization** (`installed == bundled`, content differs) — show the diff first: "orchestrate v1.13 == bundled but **12 lines were hand-edited** (diff below) — overwriting DISCARDS them. Overwrite / skip / cancel." Default to skip; if they overwrite, tell them to re-apply the edit.
+- **back-port candidate** (`installed > bundled`) — "profile-fleet installed v1.6 is **ahead** of bundled v1.4 — overwriting is a DOWNGRADE and loses field-hardening. Recommend skip and back-port the installed copy into the marketplace instead. Overwrite / skip / cancel." Default to skip.
+
+A fresh install (no existing copy) skips all of this and just copies.
 
 ```bash
 for skill in discover-agents compose-system orchestrate sync-fleet-to-head profile-fleet fleet-reconcile; do
@@ -353,7 +430,8 @@ orchestrator's own repo work.
 | Situation | Action |
 |---|---|
 | Not in an agent dir (no CLAUDE.md) | Ask for path or refuse |
-| A target skill dir already exists | Ask per-skill: overwrite / skip / cancel |
+| A target skill dir already exists | Run the **Check mode** comparison for that skill, then ask per-skill: overwrite / skip / cancel — with the verdict (upgrade / back-port candidate / local customization + diff) in the prompt |
+| `--check` invoked | Run **Check mode** only (read-only divergence report); skip all install steps |
 | `template.yaml` absent | Skip Step 6 (capabilities block); note the agent isn't self-describing yet |
 | `gh` missing and a source is `github:...` | The installed `/discover-agents` falls back to `git clone --depth 1`; warn here |
 | `gh` installed but not authenticated | Warn at preflight; `github:` sources degrade to anonymous clone (public repos only) and Q3's registry probe catches the project layer |
@@ -364,4 +442,4 @@ orchestrator's own repo work.
 
 ## Idempotency
 
-Re-running is safe: existing `fleet/sources.yaml`, `fleet/system-map.yaml`, and `fleet/orchestration.md` are never clobbered (only seeded when absent); the CLAUDE.md section, the `@fleet/orchestration.md` import, and the dashboard panel are each grep-guarded; the §3b ownership-matrix and §3c data-layer inserts are grep-guarded on `### 3b`/`### 3c`, and the standard's §12 loop-closure insert on `## 12. Loop closure`, each applied only on an explicit yes; and skill copies prompt before overwrite. `/discover-agents` rewrites only the fenced `GENERATED:*` blocks in `orchestration.md` — your prose is never touched. To refresh, run `/discover-agents`; to re-wire a skill, delete its dir under `.claude/skills/` and re-run.
+Re-running is safe: existing `fleet/sources.yaml`, `fleet/system-map.yaml`, and `fleet/orchestration.md` are never clobbered (only seeded when absent); the CLAUDE.md section, the `@fleet/orchestration.md` import, and the dashboard panel are each grep-guarded; the §3b ownership-matrix and §3c data-layer inserts are grep-guarded on `### 3b`/`### 3c`, and the standard's §12 loop-closure insert on `## 12. Loop closure`, each applied only on an explicit yes; and skill copies prompt before overwrite, the prompt now carrying the **Check mode** verdict (upgrade / back-port candidate / local customization) so a re-run never silently downgrades a field-hardened copy or discards a local edit. `/add-orchestrator --check` is fully read-only — it writes nothing and is safe to run anytime. `/discover-agents` rewrites only the fenced `GENERATED:*` blocks in `orchestration.md` — your prose is never touched. To refresh, run `/discover-agents`; to re-wire a skill, delete its dir under `.claude/skills/` and re-run.

--- a/plugins/agent-dev/skills/add-orchestrator/templates/sync-fleet-to-head.md
+++ b/plugins/agent-dev/skills/add-orchestrator/templates/sync-fleet-to-head.md
@@ -3,14 +3,19 @@ name: sync-fleet-to-head
 description: Ensure every fleet agent on Trinity is running its GitHub HEAD, non-destructively (never discards local changes). Scope comes from the orchestration narrative — only agents declared in fleet/orchestration.md + fleet/system-map.yaml are touched.
 when_to_use: When you want to verify or bring the fleet's Trinity agents up to their appropriate GitHub HEAD after upstream changes — "check the agents are on latest", "sync the fleet to HEAD", "are any agents behind their repo", periodic fleet git hygiene. Pull-only and non-destructive; it never force-resets and never pushes.
 automation: gated
+argument-hint: "[--autonomous] [agent ...]"
 allowed-tools: Read, Grep, Skill, AskUserQuestion, mcp__trinity__list_agents, mcp__trinity__get_git_sync_state, mcp__trinity__get_git_status, mcp__trinity__git_pull, mcp__trinity__chat_with_agent, mcp__trinity__get_git_log
 effort: high
 user-invocable: true
 metadata:
-  version: "1.0"
+  version: "1.4"
   created: 2026-07-01
   author: orchestrator
   changelog:
+    - "1.4: `--autonomous` run mode (new Run modes section) — back-ported from the production orchestrator (issue #5). A gated skill on an unattended cron otherwise blocks on an approval prompt nobody sees and burns its whole timeout; the mode makes the cron message the bare call `/sync-fleet-to-head --autonomous`. It relaxes nothing safety-relevant: the pull ladder stays clean → stash_reapply, force_reset/reset_to_main_preserve_state stay forbidden, and a non-trivial conflict is never guessed — it becomes a needs-attention line. Auto-proceeding past Step 4 is safe precisely because every action below it is non-destructive by construction — that invariant earns the mode, not convenience. The bundle-wide convention this instantiates is tracked in issue #6"
+    - "1.3: Error Recovery row for the 400 submodule-fetch failure — `git pull --rebase` fetches submodules and fails on an unmounted one, and MCP `git_pull` has no `--no-recurse-submodules`; flag as needs-attention with a direct-Bash workaround, do not retry"
+    - "1.2: Distinguish two 409 subtypes from `clean` — 'unstaged changes' (dirty tree → escalate to stash_reapply) vs 'unmerged files' (pre-existing conflict state; stash_reapply also fails → go straight to Step 6); Error Recovery rows for both"
+    - "1.1: Operational note — `get_git_sync_state` lags after `git_pull` (persisted cache, not live); confirm the real post-pull HEAD via `get_git_status`; Final Step verification updated accordingly"
     - "1.0: Initial version — narrative-scoped fleet HEAD sync; non-destructive pull ladder (clean -> stash_reapply), stash-reapply-warning detection, trivial-conflict union-resolve via chat_with_agent, ahead/no-repo/out-of-scope handling; two approval gates"
 ---
 
@@ -48,6 +53,29 @@ ultrathink — git edge cases (rebase-vs-dirty-tree, partial stash pops, real me
 
 - `/discover-agents` — rebuilds `fleet/system-map.yaml` from `fleet/sources.yaml` and live Trinity. Invoked only when the map is missing or stale; this playbook otherwise **reads** the map, it does not regenerate it.
 
+## Run modes
+
+Two modes. The mode comes from `$ARGUMENTS` — never from prose in a caller's message.
+
+| mode | trigger | approval gates | on non-trivial conflict |
+|---|---|---|---|
+| **interactive** *(default)* | `/sync-fleet-to-head` | Step 4 (plan) + Step 6 (conflicts) | stop and hand to the human |
+| **autonomous** | `/sync-fleet-to-head --autonomous` | none — never calls `AskUserQuestion` | skip that agent, report as needs-attention |
+
+Bare agent names restrict scope to that subset.
+
+### Autonomous mode contract
+
+Auto-proceeding is safe here for one specific reason: **every action this playbook takes is non-destructive by construction.** That invariant is what earns the mode, and autonomous mode does not relax any part of it.
+
+1. **Never call `AskUserQuestion`.** Step 4 becomes log-the-plan-and-proceed; Step 6's gate becomes skip-and-report.
+2. **The pull ladder is unchanged:** `clean` → `stash_reapply`, nothing further. `force_reset` and `reset_to_main_preserve_state` remain forbidden in every mode.
+3. **Never guess a conflict resolution.** Trivial union-mergeable files (`.gitignore`, lock files, append-only manifests) may still be resolved per Step 6. Anything else — source, semantic config — is left alone: the local work stays safe in the stash and the agent becomes a needs-attention line.
+4. **Never push to an agent repo, never commit on an agent's behalf** (true in both modes).
+5. **Report** per-agent outcome — in-sync / pulled / dirty-skipped / conflict / permission / error — and list every agent whose git state needs a human clearly as needs-attention. Do not "fix" a broken git state destructively.
+
+This is the per-skill instance of a bundle-wide `--autonomous` convention (issue #6).
+
 ## Process
 
 ### Step 1: Load scope from the narrative
@@ -78,7 +106,9 @@ For every in-scope + GitHub-backed agent, call `get_git_sync_state` (compact —
 - **ahead** — ahead > 0, behind 0 → **unpushed local commits**; flag, do **not** touch (not behind = nothing to pull; pushing is out of scope).
 - **diverged** — ahead > 0 and behind > 0 → attempt non-destructive pull; likely needs manual resolution (Step 6).
 
-### Step 4: Present the plan — [APPROVAL GATE]
+### Step 4: Present the plan — [APPROVAL GATE — interactive mode only]
+
+**Autonomous mode:** print the same table to the run result, then proceed to Step 5 without asking. Every action below is non-destructive (Run modes item 2).
 
 Show a single table and wait for approval before any pull:
 
@@ -99,7 +129,8 @@ For each agent to pull, walk this ladder — stop at the first success:
 
 1. `git_pull(strategy: "clean")`.
    - Success → done for this agent.
-   - **409 with unstaged/uncommitted changes** (`"cannot pull with rebase: You have unstaged changes"`) → `clean` rebases and refuses on a dirty tree. This is expected; escalate to step 2. Nothing was changed.
+   - **409 "cannot pull with rebase: You have unstaged changes"** → `clean` rebases and refuses on a dirty tree. This is expected; escalate to step 2. Nothing was changed.
+   - **409 "Pulling is not possible because you have unmerged files"** → pre-existing conflict state in the working tree (UU/AA/DD entries from a prior failed merge or stash pop). `stash_reapply` will also fail here (`git stash` refuses with unmerged files). Skip step 2 and go directly to Step 6. Call `get_git_status` first to identify the conflicted paths.
 2. `git_pull(strategy: "stash_reapply")` — stashes local changes, pulls, reapplies.
    - `success: true` with **no** warning → done; local changes preserved.
    - `success: true` **with `"Could not reapply local changes"`** in the message → the stash pop hit a conflict. **The local changes are NOT lost** (retained in the stash + left as conflict markers), but they are not applied. Go to Step 6. **Do not** treat this as clean success.
@@ -107,7 +138,7 @@ For each agent to pull, walk this ladder — stop at the first success:
 
 **Never** call `git_pull(strategy: "force_reset")` and **never** call `reset_to_main_preserve_state` — both discard local history. If a divergence genuinely can't be resolved non-destructively, hand it to the human (Step 6); do not force.
 
-### Step 6: Conflict handling — [APPROVAL GATE for anything non-trivial]
+### Step 6: Conflict handling — [APPROVAL GATE for anything non-trivial — interactive mode only]
 
 Call `get_git_status` for the agent and find unmerged paths (`UU` / `AA` / `DD`).
 
@@ -124,13 +155,13 @@ Call `get_git_status` for the agent and find unmerged paths (`UU` / `AA` / `DD`)
              `git rev-parse --short HEAD`, and `git stash list`.")
   ```
 
-- **Non-trivial conflicts** (source code, semantic config) → **STOP for this agent.** Do not guess a resolution. Report the conflicted files; the local work is safe in the stash. This is the gate — hand it to the human. Move on to the remaining agents.
+- **Non-trivial conflicts** (source code, semantic config) → **STOP for this agent.** Do not guess a resolution. Report the conflicted files; the local work is safe in the stash. This is the gate — hand it to the human. Move on to the remaining agents. **Autonomous mode:** identical behaviour, minus the prompt — the agent becomes a needs-attention line in the run result.
 
 Never `git commit` or `git push` during resolution unless the user explicitly asks.
 
 ### Final Step: Verify and report
 
-Re-call `get_git_sync_state` for each acted agent and confirm `behind_working == 0`. Then report a compact before → after summary:
+Re-call `get_git_sync_state` for each acted agent. **Note:** the sync-state row can lag after a pull (it's a persisted cache, not live). If it still shows `behind_working > 0`, fall back to `get_git_status` to confirm the actual HEAD commit SHA and `behind: 0`. Trust `get_git_status` over `get_git_sync_state` for post-pull verification. Then report a compact before → after summary:
 
 - **Pulled to HEAD:** agent → new short SHA.
 - **Already at HEAD:** count / list.
@@ -157,7 +188,9 @@ Re-call `get_git_sync_state` for each acted agent and confirm `behind_working ==
 |---|---|
 | `fleet/system-map.yaml` missing or stale | Invoke `/discover-agents` to (re)build it, then re-read. |
 | `get_git_*` permission denied for an agent | Insufficient key scope — skip, list under "permission-skipped", continue. |
-| `clean` returns 409 unstaged changes | Expected on a dirty tree (clean = rebase). Escalate to `stash_reapply`. |
+| `clean` returns 409 "unstaged changes" | Expected on a dirty tree (clean = rebase). Escalate to `stash_reapply`. |
+| `clean` returns 409 "unmerged files" | Pre-existing conflict state — `stash_reapply` also fails. Go directly to Step 6: call `get_git_status` to identify conflicted paths; non-trivial files → flag for human, do not auto-resolve. |
+| `clean` returns 400 "Could not access submodule" | `git pull --rebase` tries to fetch submodules and fails when a submodule is unmounted. MCP `git_pull` has no `--no-recurse-submodules` option. Flag as needs-attention; suggest the agent run `git pull --no-recurse-submodules origin main` directly via `chat_with_agent` Bash. Do not retry with `stash_reapply` (same underlying fetch fails). |
 | `stash_reapply` success **with** "Could not reapply local changes" | Stash pop conflicted; go to conflict handling. Local work is in the stash — do not drop it. |
 | Real merge conflict on non-trivial files | STOP for that agent; report conflicted paths; leave the stash intact for the human. |
 | `chat_with_agent` returns `queued_timeout` | The task is still running — poll `get_execution_result(execution_id)`; do NOT re-send (duplicate-guard will kill it). |


### PR DESCRIPTION
Closes #8 (add-orchestrator-scoped version; framework-wide follow-up filed separately).

## Problem
Re-running `/add-orchestrator` offered overwrite / skip / cancel per skill with **no version comparison, no diff, and no detection that a local copy was customized**. Two real failures this week:
- Corbin's `/orchestrate` carried a hand-written marketing-hierarchy routing block (Eugene directive). A plain overwrite would have destroyed it silently — it had to be re-applied by hand.
- Two skills sat **ahead** of the bundle for weeks and nobody noticed, because nothing ever compared the two directions (that is issue #5's whole existence).

## What this adds
A read-only **`--check`** mode on `/add-orchestrator` that, per installed runtime skill, reports the three states — and wires the same comparison into Step 4's overwrite prompt so the warning arrives **at the moment of decision**, not after:

| State | Verdict | Meaning |
|---|---|---|
| `installed < bundled` | WARN | upgrade available |
| `installed > bundled` | **FAIL** | **back-port candidate** — installed copy is ahead of the bundle; overwrite = silent downgrade (the signal #5 went weeks without) |
| `installed == bundled`, content differs | WARN | local customization — diff surfaced **before** overwrite |
| `installed == bundled`, identical | PASS | in sync |

Reported in the **canon-doctor PASS/WARN/FAIL** shape with a one-line fleet-readable verdict (orchestrators dispatch it fleet-wide and read only that line). Version compare is numeric-per-component (`1.9 < 1.13`), tested against all four states end-to-end.

## Deliberately left out (minimal scope, per Eugene's ruling)
- **The plugin-framework-wide version** — every plugin that copies skills into agent repos has this same gap, but that is a larger framework-surface call. Filed as a follow-up; this PR is add-orchestrator-only.
- **No new on-disk state / skill-registry inventory** — the check is stateless: the bundle is the reference, the installed copy is the subject, compared live.
- **No cross-version historical diff** — the bundle only carries the *current* template, so a clean local-customization diff is only possible at equal version; the behind case leads with the version gap. Documented as a caveat rather than built around.

## Overlap with PR #9 (issue #7) — still OPEN, not yet merged
#9 also bumps this skill and `agent-dev/plugin.json`. To avoid a version collision I **skip 1.21 / 1.14.1** (reserved for #9): add-orchestrator `1.20 -> 1.22`, agent-dev plugin `1.14.0 -> 1.14.2`. Whichever merges second will hit a mechanical conflict on the `SKILL.md` frontmatter (changelog prepend) and `plugin.json` version line — both trivial to reconcile. No template files (`orchestrate.md`, `discover-agents.md`) touched here, so #9's body changes don't overlap.

Files changed: `plugins/agent-dev/skills/add-orchestrator/SKILL.md`, `plugins/agent-dev/.claude-plugin/plugin.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)