### PR TITLE
docs(add-orchestrator): promote --autonomous to a bundle-wide run-mode convention (#6)

### DIFF
--- a/plugins/agent-dev/.claude-plugin/plugin.json
+++ b/plugins/agent-dev/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-dev",
   "description": "Develop and extend existing agents \u2014 add skills, memory systems, GitHub Issues development workflow (backlog, roadmap, groom, claim, autoplan, commit, sprint, work-loop), long-running multi-stage pipelines (add-pipeline + heartbeat / status / recover / pause / resume runtime skills), system-aware orchestration (add-orchestrator \u2014 discover / compose / orchestrate a multi-agent system via Trinity's SystemManifest), a shared canonical-data layer (add-canon \u2014 a fleet canon repo with publish / consume / reconcile / doctor runtime skills and per-counterpart relations memory; add-canon-lint \u2014 deterministic consistency linting of the canon repo: two-zone schema, one-home-per-key facts, CI on every push), and fleet analysis + migration (agent-fleet-analysis \u2014 scan directories of agents in any paradigm, score fleet maturity / migration readiness, recommend a fleet architecture, map every gap to an installable marketplace skill, and emit a PDF report plus an agent-executable markdown work order; agent-fleet-migrate \u2014 execute that work order non-destructively: copy sources into a fresh workspace, extract logic per paradigm (n8n nodes / framework code / freeform prompts), delegate every fix to a named marketplace skill, verify each copy through the review gate, and report the before/after maturity delta with a gated Trinity deploy offer)",
-  "version": "1.14.3",
+  "version": "1.14.4",
   "author": {
     "name": "Ability.ai",
     "email": "support@ability.ai"

--- a/plugins/agent-dev/skills/add-orchestrator/SKILL.md
+++ b/plugins/agent-dev/skills/add-orchestrator/SKILL.md
@@ -5,10 +5,11 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion, Skill
 user-invocable: true
 argument-hint: "[--check]"
 metadata:
-  version: "1.23"
+  version: "1.24"
   created: 2026-07-01
   author: Ability.ai
   changelog:
+    - "1.24: Document the bundle-wide `--autonomous` run-mode convention (issue #6) — the canonical contract the per-skill instances (`/sync-fleet-to-head` v1.4, `/profile-fleet` v1.6, back-ported in #5) now point at instead of each re-deriving it: mode comes from `$ARGUMENTS` never a caller's prose; in autonomous mode the skill never calls `AskUserQuestion`, takes the safe default at each gate, never takes a destructive/irreversible path a gate was protecting, and turns a non-trivial decision into a `needs-attention` line rather than a guess. The invariant that *earns* the mode is that every below-the-gate action is non-destructive by construction. Promotes what corbin invented per-skill on live crons into a documented marketplace convention, so a gated skill on an unattended cron stops blocking on an unseen prompt and burning its whole timeout. Enforcement is mechanical: `/audit-wizards` flags any `automation: gated` skill listed in a `schedules:` block without a declared autonomous mode. (Versions 1.21–1.23 are the other in-flight PRs #9/#8/#5.)"
     - "1.23: Back-port the two stranded runtime skills from the production orchestrator (issue #5), closing the field-hardening back-flow gap. /sync-fleet-to-head 1.0 → 1.4 (post-pull sync-state cache-lag note, two 409 subtypes — unstaged vs unmerged files, 400 submodule-fetch recovery row, and a --autonomous run mode). /profile-fleet 1.4 → 1.6 (autonomy-toggle cross-check — enabled schedules + autonomy_enabled:false is a silent no-op — and a --autonomous run mode; allowed-tools gains get_schedule_executions to match the new body). Universalized rather than swapped verbatim: dropped the corbin-specific Step 0 refresh_workspace.sh scaffolding and re-homed profile-fleet's autonomous correction queue from corbin's fleet-gap-analysis/status.yaml onto the bundle's own /fleet-reconcile convention (.claude/skills/profile-fleet/status.yaml). The --autonomous mode is landed per-skill here; its promotion to a bundle-wide convention + an /audit-wizards gate is issue #6. (Version takes 1.23 to sit above the in-flight 1.21 reserved for PR #7/#9 and 1.22 for issue #8.)"
     - "1.22: Install-time divergence detection (issue #8) — a read-only `--check` mode compares every installed runtime skill against its bundled template on three axes: `installed < bundled` (upgrade available), `installed > bundled` (BACK-PORT candidate — the field-hardened copy the marketplace should pull from, the signal issue #5 went weeks without), and equal version but differing content (local customization). Reported in the canon-doctor PASS/WARN/FAIL shape with a one-line fleet-readable verdict. Step 4's per-skill overwrite prompt now runs the same comparison, so the warning — a silent downgrade or an about-to-be-clobbered local edit — arrives at the moment of decision, not after. Deliberately scoped to add-orchestrator's own bundle and stateless; the plugin-framework-wide version is a separate follow-up. (Version skips 1.21, reserved for the open PR #7/#9.)"
     - "1.21: allowed-tools↔body drift fixes (issue #7) — /discover-agents v1.8 adds mcp__trinity__report to its grant (the Step 7 fleet_scan report was in the body but ungranted, silently never publishing under enforcement); /orchestrate v1.14 drops the three vestigial schedule tools (create/delete/list_agent_schedule) the v1.7 watchdog stopped using. Both are grant-vs-body hygiene, no behaviour change"
@@ -99,6 +100,30 @@ Drive (opt-in project-management layer — Q3 at install):
 | `fleet/system.yaml` | agent repo | Trinity manifest (written by `/compose-system`) |
 | CLAUDE.md `## Orchestration` section + `@fleet/orchestration.md` import | agent repo | wires the skills + loads the narrative at session start |
 | dashboard.yaml `Fleet` section | agent repo (if present) | table widget (Trinity's `sections[]`→`widgets[]` schema) — rows materialized by `/discover-agents` after each scan |
+
+---
+
+## Run-mode convention — `--autonomous` for gated skills on crons
+
+**The problem this fixes.** A skill that declares `automation: gated` calls `AskUserQuestion` at its decision points. Put that same skill on an unattended Trinity cron and every run blocks on an approval prompt nobody sees, then burns its **entire timeout** with nothing committed. The adaptations that make such a skill cron-safe (skip the prompt, choose the safe default, scope the commit) must live **in the versioned skill**, not in the scheduler's message — a scheduler message is unversioned, untestable, invisible to anyone invoking the skill by hand, and destroyed by the next schedule rewrite.
+
+So every bundled skill that is both `automation: gated` **and** designed to run on a cron declares a `--autonomous` run mode. This section is the **canonical contract**; each such skill carries a `### Autonomous mode contract` subsection that is the per-skill *instance* of it, not a fresh re-derivation. `/sync-fleet-to-head` and `/profile-fleet` are the first two instances (back-ported from the production orchestrator, issue #5).
+
+**The contract (all five clauses hold in every autonomous-mode skill):**
+
+1. **Mode comes from `$ARGUMENTS`, never from a caller's prose.** The trigger is the literal `--autonomous` token in the invocation, so the cron message is the bare call — `/<skill> --autonomous` — and nothing else. A chat sentence that merely *sounds* unattended does not enable the mode.
+2. **Never call `AskUserQuestion`.** Each gate degrades to *log-the-plan-and-proceed* (for a safe default) or *skip-and-report* (for anything that would otherwise need a human).
+3. **Take the safe default at each gate; never take a destructive or irreversible path a gate was protecting.** The invariant that *earns* the mode is that **every below-the-gate action is non-destructive by construction** — auto-proceeding is safe precisely because the worst outcome is a no-op, not damage. Autonomous mode relaxes *who approves*, never *what is permitted*: forbidden operations stay forbidden in every mode.
+4. **Never guess a non-trivial decision — record it.** A genuinely ambiguous choice (a conflict that isn't trivially union-mergeable, a semantic edit, anything a gate existed to catch) becomes a **`needs-attention`** line in the run result and is left untouched, never resolved by a guess.
+5. **Always report per-item outcome**, and surface every `needs-attention` item clearly so a human can close it later. A run that could do nothing safely still reports — silence is not an outcome.
+
+**Declaring the mode in a skill (what the audit checks for):**
+- `argument-hint` includes `[--autonomous]`.
+- The body carries a **Run modes** table (default vs `--autonomous`) and an **### Autonomous mode contract** subsection instantiating the five clauses above, closing with a pointer back here: *"the per-skill instance of a bundle-wide `--autonomous` convention (issue #6)."*
+
+**Mechanical enforcement.** `/audit-wizards` runs a deterministic gate that flags any skill declaring `automation: gated` which is listed in a `schedules:` block yet declares **no** autonomous mode — the exact class of bug that left a gated `/video-intake` blocking on an unseen prompt every day. A gate FAIL blocks publish; the fix is to add the `--autonomous` mode above, not to remove the skill from the schedule.
+
+`automation: autonomous` skills (e.g. `/project-steward`) already never prompt and are out of scope; `automation: manual` skills are never scheduled and are out of scope. The convention targets exactly the `automation: gated` ∩ scheduled intersection.
 
 ---
 


### PR DESCRIPTION
Promotes `--autonomous` from the per-skill patches back-ported in **#5** (`sync-fleet-to-head` v1.4, `profile-fleet` v1.6) to a **documented bundle-wide / marketplace-wide run-mode convention** — issue #6, option (3), per Eugene's minimal ruling and PR #10's handoff note.

## Scope (only these two things, per the ruling)

**(a) The documented `--autonomous` contract** — new section in `add-orchestrator/SKILL.md`, *Run-mode convention — `--autonomous` for gated skills on crons*. It is the canonical contract the per-skill `### Autonomous mode contract` subsections now point at instead of each re-deriving it:

- mode comes from `$ARGUMENTS`, **never** a caller's prose (cron message is the bare `/<skill> --autonomous`);
- in autonomous mode **never call `AskUserQuestion`**; take the safe default at each gate;
- **never** take a destructive/irreversible path a gate was protecting;
- a non-trivial decision becomes a **`needs-attention`** line, not a guess;
- the invariant that *earns* the mode: every below-the-gate action is non-destructive by construction.

**(b) The `/audit-wizards` gate** — a deterministic check that flags any `automation: gated` skill listed in a `schedules:` block **without** a declared autonomous mode (the check that would have mechanically caught ruby's gated `/video-intake` blocking on an unseen prompt every day). The contract section documents the enforcement; the gate itself lands in the marketplace manager's `/audit-wizards` skill (trinity-pm), where the marketplace quality gates live and stay in lockstep with `/test-wizard`.

## Not in scope (already landed elsewhere)

The **per-skill** `--autonomous` edits are **not** re-landed here — they are in **PR #10 (#5)**. This PR only documents the convention those instances point at, and adds its mechanical enforcement.

## Version bumps

`add-orchestrator` **1.20 → 1.24**, `agent-dev` plugin **1.14.0 → 1.14.4** — an increment **above** the three in-flight PRs (PR #9 → 1.21/1.14.1, #8 → 1.22/1.14.2, #10/#5 → 1.23/1.14.3) so whichever merges last resolves a trivial changelog/version conflict by keeping all entries and the highest number. This PR touches only `add-orchestrator/SKILL.md` + `agent-dev/plugin.json`.

## Verification

Deterministic gates on the changed files, all green: fence integrity (22, even; no nested-fence B4), `name` ≡ directory, secret scan clean, `plugin.json` + `marketplace.json` valid JSON.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)